### PR TITLE
Route53 を ID ではなく name で指定するように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Provision an AWS certificate.
 ```hcl
 module "certificate" {
   source = "realglobe-Inc/acm-certificate/aws"
-  version = "1.0.0"
-  domain_names = ["example.com"]
-  route53_zone_id = "xxxxxxx"
+  version = "2.0.0"
+  domain_names = ["example.com", "foo.example.com"]
+  route53_zone_name = "example.com."
   acm_cert_tag_name = "example.com"
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+data "aws_route53_zone" "zone" {
+  name = var.route53_zone_name
+}
+
 resource "aws_acm_certificate" "cert" {
   domain_name = var.domain_names[0]
   subject_alternative_names = slice(var.domain_names, 1, length(var.domain_names))
@@ -22,7 +26,7 @@ resource "aws_route53_record" "cert_validation" {
   name    = lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_name")
   type    = lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_type")
   records = [lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_value")]
-  zone_id = var.route53_zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   ttl     = 60
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "domain_names" {
   type = list(string)
 }
-variable "route53_zone_id" {}
+variable "route53_zone_name" {}
 variable "acm_cert_tag_name" {}


### PR DESCRIPTION
そのほうが variable がわかりやすいので。

variable の渡し方に互換性がないのでメジャーバージョンを上げた。