### PR TITLE
subject_alternative_names が複数ある場合の不具合を一時的に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Provision an AWS certificate.
 ```hcl
 module "certificate" {
   source = "realglobe-Inc/acm-certificate/aws"
-  version = "2.0.0"
+  version = "2.0.1"
   domain_names = ["example.com", "foo.example.com"]
   route53_zone_name = "example.com."
   acm_cert_tag_name = "example.com"

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,12 @@ resource "aws_acm_certificate" "cert" {
 
   lifecycle {
     create_before_destroy = true
+    # SAN に複数のドメインを指定するとランダムな順序で並べ替えてリソースが作成されるため、apply するたびに再作成になる
+    # 一時的な解決策として ignore_changes を使用する
+    # See https://github.com/terraform-providers/terraform-provider-aws/issues/8531
+    ignore_changes = [
+      subject_alternative_names,
+    ]
   }
 }
 


### PR DESCRIPTION
subject_alternative_names リストの要素が複数あると、apply でリソースが作成されるときにランダムな順序で作成されるという [issue](https://github.com/terraform-providers/terraform-provider-aws/issues/8531) がある。これで何が困るかというと、apply で一度証明書を作成し、もう一度 apply すると、subject_alternative_names に変更があることになって証明書を再作成しようとする。この問題を防ぐため、aws_acm_certificate リソースに ignore_changes を書き加えた。
