### PR TITLE
Add validate_certificate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Provision an AWS certificate.
 ```hcl
 module "certificate" {
   source = "realglobe-Inc/acm-certificate/aws"
-  version = "2.0.1"
+  version = "2.1.0"
   domain_names = ["example.com", "foo.example.com"]
   route53_zone_name = "example.com."
   acm_cert_tag_name = "example.com"

--- a/main.tf
+++ b/main.tf
@@ -23,12 +23,13 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_acm_certificate_validation" "cert" {
+  count = var.validate_certificate ? 1 : 0
   certificate_arn         = aws_acm_certificate.cert.arn
   validation_record_fqdns = aws_route53_record.cert_validation.*.fqdn
 }
 
 resource "aws_route53_record" "cert_validation" {
-  count   = length(var.domain_names)
+  count   = var.validate_certificate ? length(var.domain_names) : 0
   name    = lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_name")
   type    = lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_type")
   records = [lookup(aws_acm_certificate.cert.domain_validation_options[count.index], "resource_record_value")]
@@ -38,4 +39,6 @@ resource "aws_route53_record" "cert_validation" {
   lifecycle {
     ignore_changes = ["fqdn"]
   }
+
+  depends_on = [aws_acm_certificate.cert]
 }

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,3 @@
 output "arn" {
-  value = aws_acm_certificate_validation.cert.certificate_arn
+  value = aws_acm_certificate.cert.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,3 +3,7 @@ variable "domain_names" {
 }
 variable "route53_zone_name" {}
 variable "acm_cert_tag_name" {}
+variable "validate_certificate" {
+  type = bool
+  default = true
+}


### PR DESCRIPTION
`var.validate_certificate` はデフォルトで true で、false にすると証明書バリデーション用の Route53 レコードとかを作成しない。まれにこういうのが必要になるケースがある。
